### PR TITLE
#2 fixed typo in Avatar error response

### DIFF
--- a/apps/dialogue/src/dialogue.speech.service.ts
+++ b/apps/dialogue/src/dialogue.speech.service.ts
@@ -180,7 +180,7 @@ export class DialogueSpeechService {
       const errorMessage = await this.translateMessage(
         {
           ...dialogueMessagePayload,
-          text: 'Sorry, could you retry ?',
+          text: 'Sorry, could you retry?',
           language: 'en-GB',
         },
         language,


### PR DESCRIPTION
There was an extra space in this error message.

This address the following issue:
https://github.com/sermas-eu/sermas-toolkit-api/issues/2

Multiple error messages are concatenated without a space, PROBABLY due to lines 235-238 [here](https://github.com/sermas-eu/sermas-toolkit-web/blob/main/src/ui.ts)

```javascript
    message.content.text = chunks
      .sort(this.sortChunks)
      .map((c) => c.content.text)
      .join('');
```
We can either modify this `.join` OR add a space at the end of the error message.
I do not know the project enough to come up with an informed solution.
Please give me some directions if you want me to make other changes.
