### PR TITLE
Issue/5 run toolkit with ollama

### DIFF
--- a/apps/detection/src/providers/sentiment-analysis/sentiment-analysis.chatgpt.service.ts
+++ b/apps/detection/src/providers/sentiment-analysis/sentiment-analysis.chatgpt.service.ts
@@ -25,7 +25,7 @@ export class ChatGPTSentimentAnalysisService {
     const system = `Please provide a sentiment of this context. 
 Answer using pipe separated format where the first value is a sentiment from the list: ${emotionList} and the second value is the associated probability. 
 example:${defaultEmotion}|I am here to help you 
-Never generate an answer, by default anser with ${defaultEmotion}|1.0`;
+Never generate an answer, by default answer with ${defaultEmotion}|1.0`;
 
     let content = '';
     try {

--- a/libs/llm/llm.provider.service.ts
+++ b/libs/llm/llm.provider.service.ts
@@ -192,9 +192,8 @@ export class LLMProviderService implements OnModuleInit {
       case 'ollama':
         provider = new OllamaChatProvider({
           provider: config.provider,
-          baseURL: config.baseURL || this.config.get('OLLAMA_URL'),
+          baseURL: config.baseURL || this.config.get('OLLAMA_BASEURL'),
           model,
-          apiKey: config.apiKey || '',
           availableModels,
         });
         break;

--- a/libs/llm/llm.provider.service.ts
+++ b/libs/llm/llm.provider.service.ts
@@ -334,7 +334,6 @@ export class LLMProviderService implements OnModuleInit {
           provider: config.provider,
           baseURL: config.baseURL || this.config.get('OLLAMA_BASEURL'),
           model,
-          apiKey: config.apiKey || this.config.get('OLLAMA_API_KEY'),
           binaryQuantization,
         });
         break;

--- a/libs/llm/llm.provider.service.ts
+++ b/libs/llm/llm.provider.service.ts
@@ -125,7 +125,7 @@ export class LLMProviderService implements OnModuleInit {
     return [defaultProvider, defaultModel];
   }
 
-  getAvailableModels(provider: LLMProvider): string[] | undefined {
+  getAllowedModels(provider: LLMProvider): string[] | undefined {
     const configKey: string = `${provider.toUpperCase()}_CHAT_MODELS`;    
     const list = this.config.get(configKey);
     this.logger.verbose(`Retrieved configured models for ${configKey}: ${list}`);
@@ -186,7 +186,7 @@ export class LLMProviderService implements OnModuleInit {
     const model =
       config.model || this.getDefaultChatProviderModel(config.provider);
 
-    const availableModels = this.getAvailableModels(config.provider);  // TODO - K: Maybe rename to "getAllowedModels"?
+    const availableModels = this.getAllowedModels(config.provider);
 
     switch (config.provider) {
       case 'ollama':

--- a/libs/llm/llm.provider.service.ts
+++ b/libs/llm/llm.provider.service.ts
@@ -243,8 +243,8 @@ export class LLMProviderService implements OnModuleInit {
     if (!valid) {
       const providerModels = await provider.getModels();
       throw new Error(
-        `Model ${model} is not available from provider ${config.provider}. \
-        Available models are: ${providerModels}`,
+        `Model ${model} is not available from provider ${config.provider}. ` +
+        `Available models are: ${providerModels}`,
       );
     }
 

--- a/libs/llm/llm.provider.service.ts
+++ b/libs/llm/llm.provider.service.ts
@@ -125,8 +125,10 @@ export class LLMProviderService implements OnModuleInit {
     return [defaultProvider, defaultModel];
   }
 
-  getAvalableModels(provider: LLMProvider): string[] | undefined {
-    const list = this.config.get(`${provider.toUpperCase()}_CHAT_MODELS`);
+  getAvailableModels(provider: LLMProvider): string[] | undefined {
+    const configKey: string = `${provider.toUpperCase()}_CHAT_MODELS`;    
+    const list = this.config.get(configKey);
+    this.logger.verbose(`Retrieved configured models for ${configKey}: ${list}`);
     if (!list) return undefined;
     return list.split(',').map((m) => m.trim());
   }
@@ -184,7 +186,7 @@ export class LLMProviderService implements OnModuleInit {
     const model =
       config.model || this.getDefaultChatProviderModel(config.provider);
 
-    const availableModels = this.getAvalableModels(config.provider);
+    const availableModels = this.getAvailableModels(config.provider);  // TODO - K: Maybe rename to "getAllowedModels"?
 
     switch (config.provider) {
       case 'ollama':
@@ -240,8 +242,10 @@ export class LLMProviderService implements OnModuleInit {
 
     const valid = await provider.checkModel(model);
     if (!valid) {
+      const providerModels = await provider.getModels();
       throw new Error(
-        `Model ${model} is not available from provider ${config.provider}`,
+        `Model ${model} is not available from provider ${config.provider}. \
+        Available models are: ${providerModels}`,
       );
     }
 

--- a/libs/llm/providers/base.provider.ts
+++ b/libs/llm/providers/base.provider.ts
@@ -37,6 +37,7 @@ export abstract class LLMProvider<
         const isWildcard = parts.length > 1 && parts[1] === '*';
         return (
           m === model ||  // Perfect match 
+          (parts[0] === modelName && model === modelName) ||  // Name match (tag was not specified)
           (parts[0] === modelName && isWildcard)  // Wildcard match
         );
       });

--- a/libs/llm/providers/base.provider.ts
+++ b/libs/llm/providers/base.provider.ts
@@ -27,18 +27,19 @@ export abstract class LLMProvider<
   }
 
   public async checkModel(model: string) {
+    // This tries to load models into this.models.
     await this.getModels();
-    // ignore if unset
+    // If no model list is available, we skip the check
     if (this.models === undefined) return true;
-    return (
-      this.models.filter((m) => {
+    const modelName: string = model.split(':')[0];
+    return this.models.some((m) => {
         const parts = m.split(':');
-        if (m === model || parts[0] === model) return true;
-
         const isWildcard = parts.length > 1 && parts[1] === '*';
-        return isWildcard;
-      }).length > 0
-    );
+        return (
+          m === model ||  // Perfect match 
+          (parts[0] === modelName && isWildcard)  // Wildcard match
+        );
+      });
   }
 
   getAdapter(model: string) {

--- a/libs/llm/providers/ollama/ollama.provider.ts
+++ b/libs/llm/providers/ollama/ollama.provider.ts
@@ -95,14 +95,16 @@ export class OllamaChatProvider extends LLMChatProvider {
     // check periodically
     if (!this.heartbeat) {
       this.heartbeat = setInterval(async () => {
-        this.reachable = undefined;  // TODO - K: Are we sure about this? If this is the first run, this assignment is redundant. Otherwise, maybe it's better to set it inside the cath block? What does undefined reachability mean here anyway? 
         try {
           this.reachable = await this.isOllamaReachable();
-        } catch {}
+        } catch {
+          this.reachable = false;
+        }
       }, 5000);
     }
 
-    if (this.reachable === undefined || !this.reachable) {  // TODO - K: Check with Luca
+    // Check the first time
+    if (this.reachable === undefined) {
       this.reachable = await this.isOllamaReachable();
     }
     return this.reachable;

--- a/libs/sermas/sermas.defaults.ts
+++ b/libs/sermas/sermas.defaults.ts
@@ -117,17 +117,17 @@ export const SermasDefaultConfig = {
   LLM_SERVICE: 'openai',
 
   // LLM_SERVICE_CHAT LLM service to use for textual chat in format provider/model. If not provided will use LLM_SERVICE
-  LLM_SERVICE_CHAT: 'openai/gpt-4o',
+  // LLM_SERVICE_CHAT: 'openai/gpt-4o',
   // LLM_SERVICE_TOOLS LLM service to use for tools matching  in format provider/model. If not provided will use LLM_SERVICE
-  LLM_SERVICE_TOOLS: 'openai/gpt-4o',
+  // LLM_SERVICE_TOOLS: 'openai/gpt-4o',
   // LLM_SERVICE_SENTIMENT LLM service to use for sentiment analysis  in format provider/model. If not provided will use LLM_SERVICE
-  LLM_SERVICE_SENTIMENT: 'openai/gpt-4o-mini',
+  // LLM_SERVICE_SENTIMENT: 'openai/gpt-4o-mini',
   // LLM_SERVICE_TASKS LLM service to use for task management in format provider/model. If not provided will use LLM_SERVICE
-  LLM_SERVICE_TASKS: 'openai/gpt-4o-mini',
+  // LLM_SERVICE_TASKS: 'openai/gpt-4o-mini',
   // LLM_SERVICE_INTENT LLM service to use for intent detection in format provider/model. If not provided will use LLM_SERVICE
-  LLM_SERVICE_INTENT: 'openai/gpt-4o',
+  // LLM_SERVICE_INTENT: 'openai/gpt-4o',
   // LLM_SERVICE_TRANSLATION LLM service to use for translation and rephrasing in format provider/model. If not provided will use LLM_SERVICE
-  LLM_SERVICE_TRANSLATION: 'openai/gpt-4o-mini',
+  // LLM_SERVICE_TRANSLATION: 'openai/gpt-4o-mini',
 
   // LLM_PRINT_PROMPT Print prompts to console for debug purposes
   LLM_PRINT_PROMPT: '0',

--- a/libs/sermas/sermas.defaults.ts
+++ b/libs/sermas/sermas.defaults.ts
@@ -158,8 +158,8 @@ export const SermasDefaultConfig = {
   // LITELLM_URL LiteLLM endpoint URL
   LITELLM_URL: 'http://litellm',
 
-  // OLLAMA_URL Url to Ollama
-  OLLAMA_URL: 'http://ollama:11434',
+  // OLLAMA_BASEURL Url to Ollama
+  OLLAMA_BASEURL: 'http://ollama:11434',
   // OLLAMA_MODEL Default Ollama model used as fallback
   OLLAMA_MODEL: 'sermas-llama3',
   // OLLAMA_CHAT_MODELS Supported chat models from Ollama. Leave empty to allow all available.


### PR DESCRIPTION
This PR addresses a few problems emerged while investigating https://github.com/sermas-eu/sermas-toolkit-api/issues/5

When using ollama without an OpenAPI key, application could silently fallback to OpenAPI calls.

Changes in multiple repos are needed. See first comment.

PRs include:
- Improved logs and some code refactoring
- Reviewed documentation
- Reviewed configuration (changed variable names and defaults)