### PR TITLE
fix: keycloak not enough time elapsed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18186,9 +18186,10 @@
       }
     },
     "node_modules/keycloak-connect": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-24.0.3.tgz",
-      "integrity": "sha512-kG3JH9MvttJMyGgXAvfxBj4/G5PAIFZQBNjaZ0gVcE28qspRpUKAazLnFj1L7oISOeSVXFEF4JJBwDPbnNeGKg==",
+      "version": "24.0.5",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-24.0.5.tgz",
+      "integrity": "sha512-UtDzfsAF4IimlnLjt4Cu0XGOtMUwWFmBmEnzeybQZgxrkwXclHJ0iybpRe6k3tliB2b3/+bL1yOEsFaUmllR4Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "jwk-to-pem": "^2.0.0"
       },


### PR DESCRIPTION
This fixed the "not enough time elapsed since last request" issue in keycloak.

Not sure what the actual cause was, but all error logs were coming from the package code, not ours.
![image](https://github.com/user-attachments/assets/58222fe5-1d44-4c6e-abed-35024bc13f54)


If the issue persist we could try a more recent major release (25 or 26)