### PR TITLE
Fix: Adding user text to triggerTool parameters

### DIFF
--- a/apps/dialogue/src/intent/dialogue.intent.service.ts
+++ b/apps/dialogue/src/intent/dialogue.intent.service.ts
@@ -268,6 +268,11 @@ export class DialogueIntentService {
 
         hasToolsMatches = true;
 
+        tool.values = {
+          ...(tool.values || {}),
+          value: args.text,
+        };
+
         this.triggerTool({
           tool,
           repository: matchingRepository,


### PR DESCRIPTION
I am NOT sure this is a proper fix, but I do not know how the user input (`args.text`) was passed to the `triggerTool` method before the bug appeared.